### PR TITLE
Add alignment feature for rows and columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/coverage/
 /node_modules/
 /.idea/
 /.vscode/

--- a/README.md
+++ b/README.md
@@ -152,14 +152,14 @@ Here is a list of available props for the layout
 
  Important to note again that if neither `row` or `col` is defined these props will not take effect, that's because the library cannot tell which direction the flex is running otherwise.
 
-| enum values     | `row`+`alignX` | `row`+`alignY` | `col`+`alignX` | `col`+`alignY` |
-| --------------- | :------------: | :------------: | :------------: | :------------: |
-| `flex-start`    |                |                |                |                |
-| `center`        |                |                |                |                |
-| `flex-end`      |                |                |                |                |
-| `space-around`  |                |     invalid    |     invalid    |                |
-| `space-between` |                |     invalid    |     invalid    |                |
-| `stretch`       |     invalid    |                |                |     invalid    |
+| enum values     |  `row`+`alignX` |  `row`+`alignY` |  `col`+`alignX` |  `col`+`alignY` |
+| --------------- | :-------------: | :-------------: | :-------------: | :-------------: |
+| `flex-start`    |                 |                 |                 |                 |
+| `center`        |                 |                 |                 |                 |
+| `flex-end`      |                 |                 |                 |                 |
+| `space-around`  |                 | :no_entry_sign: | :no_entry_sign: |                 |
+| `space-between` |                 | :no_entry_sign: | :no_entry_sign: |                 |
+| `stretch`       | :no_entry_sign: |                 |                 | :no_entry_sign: |
 
 ## Styles take precedence
 

--- a/README.md
+++ b/README.md
@@ -136,13 +136,26 @@ Here is a list of available props for the layout
 
 | Prop | Type | Default | Description |
 | --- | :---: | :---: | --- |
-| row | boolean/number | false | Sets style `flexDirection: 'row'`, this take precedence over the `col` prop below |
-| col | boolean/number | false | Sets style `flexDirection: 'column'` |
-| reverse | boolean | false | Reverses the direction of `row` or `col` making the style `flexDirection: 'row-reverse'` or `flexDirection: 'column-reverse'` respectively, so will need one of those enabled to work |
-| flex | boolean/number | | Sets style `flex: ${number}`, will convert `false` to `0` and `true` to `1` |
-| margin | number/array[number] | | Sets margin for top, bottom, left and right. Follows CSS rules for `margin` |
-| padding | number/array[number] | | Sets padding for top, bottom, left and right. Follows CSS rules for `padding` |
-| viewProps | object | `{}` | A set of props to pass on to the `Component` (default `View`), the layout passes through most props except ones listed in this table. So if you require any props already used by the layout, this prop is the way to declare them. Props declared here take precedence over "pass through" props |
+| `flex` | boolean/number | | Sets style `flex: ${number}`, will convert `false` to `0` and `true` to `1` |
+| `row` | boolean/number | false | Sets style `flexDirection: 'row'`, this take precedence over the `col` prop below |
+| `col` | boolean/number | false | Sets style `flexDirection: 'column'` |
+| `reverse` | boolean | false | Reverses the direction of `row` or `col` making the style `flexDirection: 'row-reverse'` or `flexDirection: 'column-reverse'` respectively, so will need one of those enabled to work |
+| `alignX` | enum | | Sets either `justifyContent` for `row` or `alignItems` for `col` with the enum value. If neither `row` or `col` is defined this prop will not take effect |
+| `alignY` | enum | | Same with `alignX` but sets `justifyContent` for col or `alignItems` for `row` |
+| `margin` | number/array[number] | | Sets margin for top, bottom, left and right. Follows CSS rules for `margin` |
+| `padding` | number/array[number] | | Sets padding for top, bottom, left and right. Follows CSS rules for `padding` |
+| `viewProps` | object | `{}` | A set of props to pass on to the `Component` (default `View`), the layout passes through most props except ones listed in this table. So if you require any props already used by the layout, this prop is the way to declare them. Props declared here take precedence over "pass through" props |
+
+For `alignX` and `alignY`, there is a table for reference when an enum value is invalid, if the value provided is invalid `center` is used instead.
+
+| enum values     | `row`+`alignX` | `row`+`alignY` | `col`+`alignX` | `col`+`alignY` |
+| --------------- | :------------: | :------------: | :------------: | :------------: |
+| `flex-start`    |                |                |                |                |
+| `center`        |                |                |                |                |
+| `flex-end`      |                |                |                |                |
+| `space-around`  |                |     invalid    |     invalid    |                |
+| `space-between` |                |     invalid    |     invalid    |                |
+| `stretch`       |     invalid    |                |                |     invalid    |
 
 ## Styles take precedence
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ Here is a list of available props for the layout
 | `padding` | number/array[number] | | Sets padding for top, bottom, left and right. Follows CSS rules for `padding` |
 | `viewProps` | object | `{}` | A set of props to pass on to the `Component` (default `View`), the layout passes through most props except ones listed in this table. So if you require any props already used by the layout, this prop is the way to declare them. Props declared here take precedence over "pass through" props |
 
-For `alignX` and `alignY`, there is a table for reference when an enum value is invalid, if the value provided is invalid `center` is used instead.
+ ### Using `alignX` and `alignY`
+
+ Here is a table for reference when an enum value is invalid in which case `center` is used instead.
+
+ Important to note again that if neither `row` or `col` is defined these props will not take effect, that's because the library cannot tell which direction the flex is running otherwise.
 
 | enum values     | `row`+`alignX` | `row`+`alignY` | `col`+`alignX` | `col`+`alignY` |
 | --------------- | :------------: | :------------: | :------------: | :------------: |

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ Here is a list of available props for the layout
 | Prop | Type | Default | Description |
 | --- | :---: | :---: | --- |
 | `flex` | boolean/number | | Sets style `flex: ${number}`, will convert `false` to `0` and `true` to `1` |
-| `row` | boolean/number | false | Sets style `flexDirection: 'row'`, this take precedence over the `col` prop below |
-| `col` | boolean/number | false | Sets style `flexDirection: 'column'` |
-| `reverse` | boolean | false | Reverses the direction of `row` or `col` making the style `flexDirection: 'row-reverse'` or `flexDirection: 'column-reverse'` respectively, so will need one of those enabled to work |
+| `row` | boolean/number | `false` | Sets style `flexDirection: 'row'`, this take precedence over the `col` prop if both are `true` |
+| `col` | boolean/number | `false` | Sets style `flexDirection: 'column'` |
+| `reverse` | boolean | `false` | Reverses the direction of `row` or `col` making the style `flexDirection: 'row-reverse'` or `flexDirection: 'column-reverse'` respectively, so will need one of those enabled to work |
 | `alignX` | enum | | Sets either `justifyContent` for `row` or `alignItems` for `col` with the enum value. If neither `row` or `col` is defined this prop will not take effect |
 | `alignY` | enum | | Same with `alignX` but sets `justifyContent` for col or `alignItems` for `row` |
 | `margin` | number/array[number] | | Sets margin for top, bottom, left and right. Follows CSS rules for `margin` |

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "coverage": "jest --coverage",
     "peerinstall": "yarn add -P --no-lockfile $(node -e \"process.stdout.write(String(Object.entries(require('./package.json').peerDependencies).map(d => d.join('@')).join(' ')))\")"
   },
   "repository": {

--- a/src/provideLayout.js
+++ b/src/provideLayout.js
@@ -22,8 +22,8 @@ export default function provideLayout(View = RNView) {
       row: PropTypes.bool,
       col: PropTypes.bool,
       reverse: PropTypes.bool,
-      xAlign: alignProps,
-      yAlign: alignProps,
+      alignX: alignProps,
+      alignY: alignProps,
       viewProps: PropTypes.object,
     };
 
@@ -35,8 +35,8 @@ export default function provideLayout(View = RNView) {
       row: false,
       col: false,
       reverse: false,
-      xAlign: null,
-      yAlign: null,
+      alignX: null,
+      alignY: null,
       viewProps: {},
     };
 
@@ -113,15 +113,15 @@ export default function provideLayout(View = RNView) {
       const {
         row,
         col,
-        xAlign,
-        yAlign,
+        alignX,
+        alignY,
       } = this.props;
 
       if (!row && !col) {
         return null;
       }
 
-      const alignProp = (row === justified) ? xAlign : yAlign;
+      const alignProp = (row === justified) ? alignX : alignY;
       const unsupported = 'center';
 
       if (justified && ['stretch'].includes(alignProp)) {
@@ -144,8 +144,8 @@ export default function provideLayout(View = RNView) {
         row,
         col,
         reverse,
-        xAlign,
-        yAlign,
+        alignX,
+        alignY,
         viewProps,
         ...props
       } = this.props;

--- a/src/provideLayout.js
+++ b/src/provideLayout.js
@@ -63,8 +63,6 @@ export default function provideLayout(View = RNView) {
 
       if (flex !== null) {
         Object.assign(flexStyles, { flex });
-      } else if (justifyContent && alignItems) {
-        Object.assign(flexStyles, { flex: 1 });
       }
 
       return flexStyles;

--- a/src/provideLayout.js
+++ b/src/provideLayout.js
@@ -77,14 +77,27 @@ export default function provideLayout(View = RNView) {
       return flex;
     }
 
+    get isRow() {
+      const { row } = this.props;
+
+      return row;
+    }
+
+    get isCol() {
+      const { row, col } = this.props;
+
+      // row takes precedence if both row and col are true
+      return !row && col;
+    }
+
     get flexDirection() {
-      const { row, col, reverse } = this.props;
+      const { reverse } = this.props;
       const reversing = reverse ? '-reverse' : '';
 
-      if (row) {
+      if (this.isRow) {
         return `row${reversing}`;
       }
-      if (col) {
+      if (this.isCol) {
         return `column${reversing}`;
       }
 
@@ -109,18 +122,19 @@ export default function provideLayout(View = RNView) {
 
     getAlignment(justified) {
       const {
-        row,
-        col,
         alignX,
         alignY,
       } = this.props;
 
-      if (!row && !col) {
-        return null;
-      }
-
-      const alignProp = (row === justified) ? alignX : alignY;
       const unsupported = 'center';
+
+      let alignProp = null;
+      if ((this.isRow && justified) || (this.isCol && !justified)) {
+        alignProp = alignX;
+      }
+      if ((this.isCol && justified) || (this.isRow && !justified)) {
+        alignProp = alignY;
+      }
 
       if (justified && ['stretch'].includes(alignProp)) {
         return unsupported;

--- a/src/tests/provideLayout.test.js
+++ b/src/tests/provideLayout.test.js
@@ -127,12 +127,41 @@ describe('provideLayout', () => {
     });
   });
 
-  describe('calculate layout', () => {
+  describe('flexStyles', () => {
     let instance = null;
-
-    beforeEach(() => {
+    const reset = () => {
       Layout = provideLayout();
       instance = new Layout({});
+    };
+
+    beforeEach(reset);
+
+    test('should be empty by default', () => {
+      instance.flex = null;
+      instance.flexDirection = null;
+      instance.justifyContent = null;
+      instance.alignItems = null;
+
+      expect(instance.flexStyles).toEqual({});
+    });
+
+    test('should provide the style when it is in the props', () => {
+      instance.props.flex = 1;
+      expect(instance.flexStyles).toEqual({ flex: 1 });
+
+      reset();
+      instance.props.row = true;
+      expect(instance.flexStyles).toEqual({ flexDirection: 'row' });
+
+      reset();
+      instance.props.row = true;
+      instance.props.alignX = 'center';
+      expect(instance.flexStyles).toEqual({ flexDirection: 'row', justifyContent: 'center' });
+
+      reset();
+      instance.props.row = true;
+      instance.props.alignY = 'center';
+      expect(instance.flexStyles).toEqual({ flexDirection: 'row', alignItems: 'center' });
     });
 
     describe('flex', () => {

--- a/src/tests/provideLayout.test.js
+++ b/src/tests/provideLayout.test.js
@@ -139,6 +139,9 @@ describe('provideLayout', () => {
       test('the value of flex in props is returned', () => {
         expect(instance.flex).toBe(undefined);
 
+        instance.props.flex = null;
+        expect(instance.flex).toBe(null);
+
         instance.props.flex = -1;
         expect(instance.flex).toBe(-1);
 
@@ -218,6 +221,114 @@ describe('provideLayout', () => {
           paddingLeft: 2,
           paddingRight: 2,
         });
+      });
+    });
+
+    describe('isCol', () => {
+      test('the col prop value is given', () => {
+        instance.props.col = true;
+        expect(instance.isCol).toBe(true);
+      });
+
+      test('the row prop takes precendence', () => {
+        instance.props.row = true;
+        instance.props.col = true;
+        expect(instance.isCol).toBe(false);
+      });
+    });
+
+    describe('isRow', () => {
+      test('the row prop value is given', () => {
+        instance.props.row = true;
+        expect(instance.isRow).toBe(true);
+      });
+
+      test('the row prop takes precendence', () => {
+        instance.props.row = true;
+        instance.props.col = true;
+        expect(instance.isRow).toBe(true);
+      });
+    });
+
+    describe('justifyContent', () => {
+      test('nothing is returned when both `row` and `col` are false', () => {
+        instance.props.row = false;
+        instance.props.col = false;
+        instance.props.alignX = 'flex-start';
+
+        expect(instance.justifyContent).toBe(null);
+      });
+
+      test('align value is returned when `row` and `alignX`', () => {
+        instance.props.row = true;
+        instance.props.alignX = 'space-around';
+
+        expect(instance.justifyContent).toBe('space-around');
+      });
+
+      test('align value is returned when `col` and `alignY`', () => {
+        instance.props.col = true;
+        instance.props.alignY = 'flex-end';
+
+        expect(instance.justifyContent).toBe('flex-end');
+      });
+
+      test('row takes precedence', () => {
+        instance.props.row = true;
+        instance.props.col = true;
+        instance.props.alignX = 'flex-start';
+
+        expect(instance.justifyContent).toBe('flex-start');
+      });
+
+      test('invalid justifyContent value fallsback to center', () => {
+        instance.props.row = true;
+        instance.props.alignX = 'stretch';
+
+        expect(instance.justifyContent).toBe('center');
+      });
+    });
+
+    describe('alignItems', () => {
+      test('nothing is returned when both `row` and `col` are false', () => {
+        instance.props.row = false;
+        instance.props.col = false;
+        instance.props.alignY = 'flex-start';
+
+        expect(instance.justifyContent).toBe(null);
+      });
+
+      test('align value is returned when `row` and `alignY`', () => {
+        instance.props.row = true;
+        instance.props.alignY = 'stretch';
+
+        expect(instance.alignItems).toBe('stretch');
+      });
+
+      test('align value is returned when `col` and `alignX`', () => {
+        instance.props.col = true;
+        instance.props.alignX = 'flex-end';
+
+        expect(instance.alignItems).toBe('flex-end');
+      });
+
+      test('row takes precedence', () => {
+        instance.props.row = true;
+        instance.props.col = true;
+        instance.props.alignY = 'flex-start';
+
+        expect(instance.alignItems).toBe('flex-start');
+      });
+
+      test('invalid alignItems value fallsback to center', () => {
+        instance.props.row = true;
+        instance.props.alignY = 'space-around';
+
+        expect(instance.alignItems).toBe('center');
+
+        instance.props.alignY = 'space-between';
+
+        expect(instance.alignItems).toBe('center');
       });
     });
   });


### PR DESCRIPTION
This enables applying the `justifyContent` and `alignItems` styles with the layit API.

The use of `center` as a fallback for invalid values (e.g. `justifyContent` does not support `stretch`), perhaps `null` would be more appropriate for later discussion