### PR TITLE
Extend width and height properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,12 @@ I had found that quite verbose for this library and pollutes the property list a
 
 To define `minWidth`, `width` and `maxWidth` you'll need to define an array for the `width` property in the format: `[minWidth, width, maxWidth]`, and the same applies for `height`.
 
-The values provided will need to be a valid number or string, otherwise it will error or be ignored altogether.
+The values provided will need to be a valid number or string (can be a percent), otherwise it will error or be ignored altogether.
 
 An example of the feature:
 
 ```jsx
-<Layit width={[30, "60%", 80]} />
+<Layit width={['30', "60%", 80]} />
 ```
 
 This means the following styles are applied:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Following the philosophy of `react-native-row`, this library helps keep unnecess
 
 ## Installation
 
-```bash
+```sh
 npm install react-native-layit
 ```
 
@@ -146,8 +146,8 @@ Here is a list of available props for the layout
 | `reverse`     |        boolean       | `false` | Reverses the direction of `row` or `col` making the style `flexDirection: 'row-reverse'` or `flexDirection: 'column-reverse'` respectively, so will need one of those enabled to work |
 | `alignX`      |         enum         |         | Sets either `justifyContent` for `row` or `alignItems` for `col` with the enum value. If neither `row` or `col` is defined this prop will not take effect |
 | `alignY`      |         enum         |         | Same with `alignX` but sets `justifyContent` for col or `alignItems` for `row` |
-| `width`       |        number        |         | Set the width, could interfer with `flex` behaviours if used together |
-| `height`      |        number        |         | Set the height, could interfer with `flex` behaviours if used together |
+| `width`       | number/array[number] |         | Set the width, could interfer with `flex` behaviours if used together. More details about min and max value below |
+| `height`      | number/array[number] |         | Set the height, could interfer with `flex` behaviours if used together. More details about min and max value below |
 | `margin`      | number/array[number] |         | Sets margin for top, bottom, left and right. Follows CSS rules for `margin` |
 | `padding`     | number/array[number] |         | Sets padding for top, bottom, left and right. Follows CSS rules for `padding` |
 | `viewProps`   |        object        |   `{}`  | A set of props to pass on to the `Component` (default `View`), the layout passes through most props except ones listed in this table. So if you require any props already used by the layout, this prop is the way to declare them. Props declared here take precedence over "pass through" props |
@@ -168,6 +168,34 @@ Here is a list of available props for the layout
 | `space-between` |                 | :no_entry_sign: | :no_entry_sign: |                 |
 | `stretch`       | :no_entry_sign: |                 |                 | :no_entry_sign: |
 
+### Using `height` and `width`
+
+Setting width and height is quite straight forward, setting them directly with `width="20"` and `height="10"`.
+
+If you want to set `min` and/or `max` for height or width, in stylesheet you'd need to define each separately.
+
+I had found that quite verbose for this library and pollutes the property list a fair amount, so instead I've extended the `width` and `height` property to cleanly allow handling `min` and `max` easily.
+
+To define `minWidth`, `width` and `maxWidth` you'll need to define an array for the `width` property in the format: `[minWidth, width, maxWidth]`, and the same applies for `height`.
+
+The values provided will need to be a valid number or string, otherwise it will error or be ignored altogether.
+
+An example of the feature:
+
+```jsx
+<Layit width={[30, "60%", 80]} />
+```
+
+This means the following styles are applied:
+
+```js
+{
+  minWidth: 30,
+  width: "60%",
+  maxWidth: 80,
+}
+```
+
 ### Using `margin` and `padding`
 
 Here is a table for what styles are applied when you use the `margin` and/or `padding`.
@@ -187,7 +215,8 @@ This behaves like the CSS rules, so if you're familiar with that, you probably a
 If there's a `style` prop which has a rule conflicting with a layout prop, the style will take precendence. This also applies for `viewProps`, if viewProps contains a style property and there's also a style prop, the viewProps style will take precedence.
 
 So the hierarchy goes like this
-```
+
+```md
  viewProps.style > style > layoutProps
 ```
 

--- a/src/dimensionsHelper.js
+++ b/src/dimensionsHelper.js
@@ -1,5 +1,14 @@
 import PropTypes from 'prop-types';
 
+const sanitize = (amount) => {
+  const numeric = Number(amount);
+
+  if (!Number.isNaN(numeric)) {
+    return numeric;
+  }
+  return amount;
+};
+
 export const calculate = (type, amount) => {
   if (type !== 'Width' && type !== 'Height') {
     throw new Error('Invalid type provided to `dimensionsHelper`: only accepts "Width" or "Height"');
@@ -8,21 +17,27 @@ export const calculate = (type, amount) => {
   const dimensions = {};
 
   if (typeof amount === 'string' || typeof amount === 'number') {
-    dimensions[prop] = amount;
+    dimensions[prop] = sanitize(amount);
   }
 
   if (!Array.isArray(amount)) {
     return dimensions;
   }
 
-  if (typeof amount[0] === 'string' || typeof amount[0] === 'number') {
-    dimensions[`min${type}`] = amount[0];
+  const [
+    min,
+    actual,
+    max,
+  ] = amount;
+
+  if (typeof min === 'string' || typeof min === 'number') {
+    dimensions[`min${type}`] = sanitize(min);
   }
-  if (typeof amount[1] === 'string' || typeof amount[1] === 'number') {
-    dimensions[prop] = amount[1];
+  if (typeof actual === 'string' || typeof actual === 'number') {
+    dimensions[prop] = sanitize(actual);
   }
-  if (typeof amount[2] === 'string' || typeof amount[2] === 'number') {
-    dimensions[`max${type}`] = amount[2];
+  if (typeof max === 'string' || typeof max === 'number') {
+    dimensions[`max${type}`] = sanitize(max);
   }
 
   return dimensions;

--- a/src/dimensionsHelper.js
+++ b/src/dimensionsHelper.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+
+export const calculate = (type, amount) => {
+  if (type !== 'Width' && type !== 'Height') {
+    throw new Error('Invalid type provided to `dimensionsHelper`: only accepts "Width" or "Height"');
+  }
+  const prop = type.toLocaleLowerCase();
+  const dimensions = {};
+
+  if (typeof amount === 'string' || typeof amount === 'number') {
+    dimensions[prop] = amount;
+  }
+
+  if (!Array.isArray(amount)) {
+    return dimensions;
+  }
+
+  if (typeof amount[0] === 'string' || typeof amount[0] === 'number') {
+    dimensions[`min${type}`] = amount[0];
+  }
+  if (typeof amount[1] === 'string' || typeof amount[1] === 'number') {
+    dimensions[prop] = amount[1];
+  }
+  if (typeof amount[2] === 'string' || typeof amount[2] === 'number') {
+    dimensions[`max${type}`] = amount[2];
+  }
+
+  return dimensions;
+};
+
+const measurement = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
+export const propTypes = PropTypes.oneOfType([
+  measurement,
+  PropTypes.arrayOf(measurement),
+]);

--- a/src/provideLayout.js
+++ b/src/provideLayout.js
@@ -1,7 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { View as RNView, ViewPropTypes, StyleSheet } from 'react-native';
-import { calculate, propTypes as gapsPropTypes } from './gapsHelper';
+import { calculate as getGaps, propTypes as gapsPropTypes } from './gapsHelper';
+import { calculate as getDimensions, propTypes as dimensionsPropTypes } from './dimensionsHelper';
 import hash from 'object-hash';
 
 const alignProps = PropTypes.oneOf([
@@ -33,8 +34,8 @@ export default function provideLayout(View = RNView, styleIndexer = StyleSheet.c
       alignY: alignProps,
       viewProps: PropTypes.object,
       cacheStyles: PropTypes.bool,
-      width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-      height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      width: dimensionsPropTypes,
+      height: dimensionsPropTypes,
     };
 
     static defaultProps = {
@@ -58,7 +59,8 @@ export default function provideLayout(View = RNView, styleIndexer = StyleSheet.c
         ...this.margins,
         ...this.paddings,
         ...this.flexStyles,
-        ...this.dimensions,
+        ...this.heights,
+        ...this.widths,
       };
 
       if (!this.props.cacheStyles) {
@@ -80,24 +82,12 @@ export default function provideLayout(View = RNView, styleIndexer = StyleSheet.c
       return styles[key];
     }
 
-    get dimensions() {
-      const { flex } = this;
-      const dimensions = {};
+    get heights() {
+      return getDimensions('Height', this.props.height);
+    }
 
-      const {
-        width,
-        height
-      } = this.props;
-
-      if (width) {
-        Object.assign(dimensions, { width: Number(width) });
-      }
-
-      if (height) {
-        Object.assign(dimensions, { height: Number(height) });
-      }
-
-      return dimensions;
+    get widths() {
+      return getDimensions('Width', this.props.width);
     }
 
     get flexStyles() {
@@ -173,11 +163,11 @@ export default function provideLayout(View = RNView, styleIndexer = StyleSheet.c
     }
 
     get margins() {
-      return calculate('margin', this.props.margin);
+      return getGaps('margin', this.props.margin);
     }
 
     get paddings() {
-      return calculate('padding', this.props.padding);
+      return getGaps('padding', this.props.padding);
     }
 
     getAlignment(justified) {

--- a/src/tests/dimensionsHelper.test.js
+++ b/src/tests/dimensionsHelper.test.js
@@ -17,7 +17,7 @@ describe('calculate', () => {
   });
 
   test('should provide min and max without lowercase if array value', () => {
-    expect(calculate('Width', [1, 2, 3])).toEqual({
+    expect(calculate('Width', [1, '2', 3])).toEqual({
       minWidth: 1,
       width: 2,
       maxWidth: 3,

--- a/src/tests/dimensionsHelper.test.js
+++ b/src/tests/dimensionsHelper.test.js
@@ -1,0 +1,37 @@
+/* global describe, test, expect */
+import { calculate } from '../dimensionsHelper';
+
+describe('calculate', () => {
+  test('should throw if invalid type', () => {
+    expect(() => calculate('Custom')).toThrow();
+    expect(() => calculate('Another')).toThrow();
+    expect(() => calculate('height')).toThrow();
+    expect(() => calculate('Height')).not.toThrow();
+    expect(() => calculate('Width')).not.toThrow();
+  });
+
+  test('should lower case the type given', () => {
+    expect(calculate('Width', 40)).toEqual({ width: 40 });
+
+    expect(calculate('Height', '40%')).toEqual({ height: '40%' });
+  });
+
+  test('should provide min and max without lowercase if array value', () => {
+    expect(calculate('Width', [1, 2, 3])).toEqual({
+      minWidth: 1,
+      width: 2,
+      maxWidth: 3,
+    });
+
+    expect(calculate('Height', ['1%', '2%', '3%'])).toEqual({
+      minHeight: '1%',
+      height: '2%',
+      maxHeight: '3%',
+    });
+  });
+
+  test('should ignore amounts that are not string or number', () => {
+    expect(calculate('Width', {})).toEqual({});
+    expect(calculate('Width', [{}, 50])).toEqual({ width: 50 });
+  });
+});

--- a/src/tests/provideLayout.test.js
+++ b/src/tests/provideLayout.test.js
@@ -225,22 +225,82 @@ describe('provideLayout', () => {
 
     beforeEach(reset);
 
-    test('should be empty by default', () => {
-      expect(instance.dimensions).toEqual({});
+    describe('widths', () => {
+      test('should be empty by default', () => {
+        expect(instance.widths).toEqual({});
+      });
+
+      test('should provide the width in the props', () => {
+        instance.props.width = '50%';
+        expect(instance.widths).toEqual({ width: '50%' });
+      });
+
+      test('should provide min and max when array is given', () => {
+        instance.props.width = [10, null, 25];
+        expect(instance.widths).toEqual({ minWidth: 10, maxWidth: 25 });
+      });
     });
 
-    test('should provide the width or height when it is in the props', () => {
-      instance.props.height = 40;
-      expect(instance.dimensions).toEqual({ height: 40 });
+    describe('heights', () => {
+      test('should be empty by default', () => {
+        expect(instance.heights).toEqual({});
+      });
 
-      reset();
-      instance.props.width = 50;
-      expect(instance.dimensions).toEqual({ width: 50 });
+      test('should provide the height in the props', () => {
+        instance.props.height = 40;
+        expect(instance.heights).toEqual({ height: 40 });
+      });
 
-      reset();
-      instance.props.height = 15;
-      instance.props.width = 69;
-      expect(instance.dimensions).toEqual({ height: 15, width: 69 });
+      test('should provide min and max when array is given', () => {
+        instance.props.height = [10, null, 25];
+        expect(instance.heights).toEqual({ minHeight: 10, maxHeight: 25 });
+      });
+    });
+  });
+
+  describe('gaps', () => {
+    let instance = null;
+    const reset = () => {
+      Layout = provideLayout();
+      instance = new Layout({});
+    };
+
+    beforeEach(reset);
+
+    describe('margins', () => {
+      test('provide margin properties', () => {
+        instance.props.margin = 1;
+        expect(instance.margins).toEqual({ margin: 1 });
+
+        instance.props.margin = [1];
+        expect(instance.margins).toEqual({ margin: 1 });
+
+        instance.props.margin = [1, 5];
+        expect(instance.margins).toEqual({
+          marginTop: 1,
+          marginBottom: 1,
+          marginLeft: 5,
+          marginRight: 5,
+        });
+      });
+    });
+
+    describe('paddings', () => {
+      test('provide padding properties', () => {
+        instance.props.padding = 3;
+        expect(instance.paddings).toEqual({ padding: 3 });
+
+        instance.props.padding = [3];
+        expect(instance.paddings).toEqual({ padding: 3 });
+
+        instance.props.padding = [7, 2, 8];
+        expect(instance.paddings).toEqual({
+          paddingTop: 7,
+          paddingBottom: 8,
+          paddingLeft: 2,
+          paddingRight: 2,
+        });
+      });
     });
   });
 
@@ -326,42 +386,6 @@ describe('provideLayout', () => {
         instance.props.row = true;
         instance.props.col = true;
         expect(instance.flexDirection).toBe('row');
-      });
-    });
-
-    describe('margins', () => {
-      test('provide margin properties', () => {
-        instance.props.margin = 1;
-        expect(instance.margins).toEqual({ margin: 1 });
-
-        instance.props.margin = [1];
-        expect(instance.margins).toEqual({ margin: 1 });
-
-        instance.props.margin = [1, 5];
-        expect(instance.margins).toEqual({
-          marginTop: 1,
-          marginBottom: 1,
-          marginLeft: 5,
-          marginRight: 5,
-        });
-      });
-    });
-
-    describe('paddings', () => {
-      test('provide padding properties', () => {
-        instance.props.padding = 3;
-        expect(instance.paddings).toEqual({ padding: 3 });
-
-        instance.props.padding = [3];
-        expect(instance.paddings).toEqual({ padding: 3 });
-
-        instance.props.padding = [7, 2, 8];
-        expect(instance.paddings).toEqual({
-          paddingTop: 7,
-          paddingBottom: 8,
-          paddingLeft: 2,
-          paddingRight: 2,
-        });
       });
     });
 


### PR DESCRIPTION
Allows for minHeight, maxHeight and the same for width without needing a separate prop for each